### PR TITLE
Fix collection optimization to finalize VTables cleanup (Extraneous data removed: memory gain)

### DIFF
--- a/adl-backend-static/src/main/resources/st/optim/definitions/header/Component.stc
+++ b/adl-backend-static/src/main/resources/st/optim/definitions/header/Component.stc
@@ -183,19 +183,13 @@ InterfaceDescriptorDecl(definition, itf, instance, isInternal) ::= <<
 // Optimized collection (server)
 <InterfaceDescType(signature=itf.signature)> <itf.name><if (itf.numberOfElement)>[<itf.numberOfElement>]<endif>;
     <else>
-      <! As we do not optimize collection interfaces, we've got to care whether a binding source is a collection so the destination isn't optimized either !>
-      <if (instance.decorations.("reverse-collection-binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)).binding.fromInterfaceNumber)>
-// No optimization : Parent has @StaticBindings but binding source is a collection
-<InterfaceDescType(signature=itf.signature)> <itf.name><if (itf.numberOfElement)>[<itf.numberOfElement>]<endif>;
-      <else>
-      	<! Maybe our interface is a controller, that we don't want to optimize: exception case !>
-      	<if (itf.astDecorations.("controller-interface"))>
+      <! Maybe our interface is a controller, that we don't want to optimize: exception case !>
+      <if (itf.astDecorations.("controller-interface"))>
 // No optimization : Parent has @StaticBindings but the interface is a controller
 <InterfaceDescType(signature=itf.signature)> <itf.name><if (itf.numberOfElement)>[<itf.numberOfElement>]<endif>;
-      	<else>
+      <else>
 // Optimized : Parent has @StaticBinding, interface is not a controller, doesn't have a collection as binding source, and isn't collection 
 // <InterfaceDescType(signature=itf.signature)> <itf.name><if (itf.numberOfElement)>[<itf.numberOfElement>]<endif>;
-      	<endif>
       <endif>
     <endif>
   <else>
@@ -418,18 +412,12 @@ ServerInterfaceVTableDecl(definition, itf) ::= <<
     <else>
       <! Optimization : Here we check if bindings from our instance are static !>
       <if (definition.astDecorations.("parent-has-static-bindings"))>
-        <! As we do not optimize collection interfaces, we've got to care whether a binding source is a collection so the destination isn't optimized either !>
-        <if (instance.decorations.("reverse-collection-binding-descriptors").(StaticBindingItfName(itfName=itf.name)).binding.fromInterfaceNumber)>
-// No optimization : default behavior 7
-extern <InterfaceVTableType(signature=itf.signature)> <vTableInstanceName(definition=definition,itf=itf)>;
-        <else>
-          <if (itf.astDecorations.("controller-interface"))>
+        <if (itf.astDecorations.("controller-interface"))>
 // No optimization : Parent has @StaticBindings but binding destination is a controller
 extern <InterfaceVTableType(signature=itf.signature)> <vTableInstanceName(definition=definition,itf=itf)>;
-      	  <else>
+      	<else>
 // Optimized : Removed reference as the VTable has already been garbaged anyway
 // extern <InterfaceVTableType(signature=itf.signature)> <vTableInstanceName(definition=definition,itf=itf)>;
-      	  <endif>
       	<endif>
       <else>
 extern <InterfaceVTableType(signature=itf.signature)> <vTableInstanceName(definition=definition,itf=itf)>;
@@ -581,15 +569,11 @@ InitializeInterface(definition, instance, itf, isInternal) ::= <<
     <if (itf.numberOfElement)>
 <InitializeServerInterface(definition=definition, itf=itf)>,
     <else>
-      <if (instance.decorations.("reverse-collection-binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)).binding.fromInterfaceNumber)>
+      <if (itf.astDecorations.("controller-interface"))>
 <InitializeServerInterface(definition=definition, itf=itf)>,
       <else>
-      	<if (itf.astDecorations.("controller-interface"))>
-<InitializeServerInterface(definition=definition, itf=itf)>,
-      	<else>
 /* <InitializeServerInterface(definition=definition, itf=itf)>, */ \
-		<endif>
-      <endif>
+		  <endif>
     <endif>
   <else>
     <if (isInternal)>
@@ -653,16 +637,11 @@ InitializeLastInterface(definition, instance, itf, isInternal) ::= <<
     <if (itf.numberOfElement)>
 <InitializeServerInterface(definition=definition, itf=itf)>
     <else>
-<! As we do not optimize collection interfaces, we've got to care whether a binding source is a collection so the destination isn't optimized either !>
-      <if (instance.decorations.("reverse-collection-binding-descriptors").(StaticBindingItfName(itfName=itf.name, isInternal=isInternal)).binding.fromInterfaceNumber)>
+      <if (itf.astDecorations.("controller-interface"))>
 <InitializeServerInterface(definition=definition, itf=itf)>
       <else>
-      	<if (itf.astDecorations.("controller-interface"))>
-<InitializeServerInterface(definition=definition, itf=itf)>
-      	<else>
 /* <InitializeServerInterface(definition=definition, itf=itf)> */ \
-		<endif>
-      <endif>
+		  <endif>
     <endif>
   <else>
     <if (isInternal)>

--- a/adl-backend-static/src/main/resources/st/optim/membrane/MembraneImplementation.stc
+++ b/adl-backend-static/src/main/resources/st/optim/membrane/MembraneImplementation.stc
@@ -428,19 +428,14 @@ ServerInterfaceStub(definition, instance, interfaceDefinitions, itf) ::= <<
 <else>
 <! SSZ : BEGIN MODIFICATION !>
 <if (definition.astDecorations.("parent-has-static-bindings"))>
-  <! As we do not optimize collection interfaces, we've got to care whether a binding source is a collection so the destination isn't optimized either !>
-  <if (instance.decorations.("reverse-collection-binding-descriptors").(StaticBindingItfName(itfName=itf.name)).binding.fromInterfaceNumber)>
-  <interfaceDefinitions.(itf.signature).methods:ServerMethodStub(definition=definition, instance=instance, itf=itf, method=it); separator="\n">
-  <else>
-  	<! We don't want to optimize controllers !>
-  	<if (itf.astDecorations.("controller-interface"))>
+  <! We don't want to optimize controllers !>
+  <if (itf.astDecorations.("controller-interface"))>
 <interfaceDefinitions.(itf.signature).methods:ServerMethodStub(definition=definition, instance=instance, itf=itf, method=it); separator="\n">
-  	<else>
+  <else>
 /* Optimized according to @StaticBindings
 <interfaceDefinitions.(itf.signature).methods:ServerMethodStub(definition=definition, instance=instance, itf=itf, method=it); separator="\n">
 */
 	<endif>
-  <endif>
 <else>
 <interfaceDefinitions.(itf.signature).methods:ServerMethodStub(definition=definition, instance=instance, itf=itf, method=it); separator="\n">
 <endif>
@@ -504,18 +499,13 @@ ServerInterfaceVTableInit(definition, interfaceDefinitions, itf) ::= <<
 */
     <else>
       <if (definition.astDecorations.("parent-has-static-bindings"))>
-      <! As we do not optimize collection interfaces, we've got to care whether a binding source is a collection so the destination isn't optimized either !>
-        <if (instance.decorations.("reverse-collection-binding-descriptors").(StaticBindingItfName(itfName=itf.name)).binding.fromInterfaceNumber)>
+        <! We don't want to optimize controllers !>
+	      <if (itf.astDecorations.("controller-interface"))>
 <ServerInterfaceVTableInit1(definition=definition, interfaceDefinitions=interfaceDefinitions, itf=itf)>
         <else>
-          <! We don't want to optimize controllers !>
-	        <if (itf.astDecorations.("controller-interface"))>
-<ServerInterfaceVTableInit1(definition=definition, interfaceDefinitions=interfaceDefinitions, itf=itf)>
-          <else>
 /* Optimized according to @StaticBindings
 <ServerInterfaceVTableInit1(definition=definition, interfaceDefinitions=interfaceDefinitions, itf=itf)>
 */
-          <endif>
         <endif>
       <else>
 <ServerInterfaceVTableInit1(definition=definition, interfaceDefinitions=interfaceDefinitions, itf=itf)>


### PR DESCRIPTION
## Remaining to be done

This nearly finalizes the new @StaticBindings implementation: It is functional, but some empty structures remain and cleanup algorithm (BasicInternalDataOptimizer) should take private data structures into account.

One more step could be to handle "_stubs" functions pointers to enable multi-instance support for @StaticBindings and remove the @Singleton-everywhere restriction.
## Done

The previous implementation had some code reminiscent of past times where we had exception cases every time we met a collection.

Here, when generating interface data for bindings destination side, if binding source was a collection, we tagged the server to tell it to keep its data since we didn't optimize collections.

Now this solution is irrelevant and led to residual useless data being written: We remove every "reverse-collection-binding-descriptor" exception section. Data gain is very sensible, as well as some effect on text section size.
